### PR TITLE
[Fix] Overlay shadow

### DIFF
--- a/src/components/LeftPanel.tsx
+++ b/src/components/LeftPanel.tsx
@@ -13,7 +13,7 @@ const LeftPanelWrapper = styled.aside<LeftPanelProps>`
   position: absolute;
   left: ${props => props.show ? '0' : '-372px'};
   top: 0;
-  z-index: 2;
+  z-index: 3;
 
   padding: 0 16px;
 

--- a/src/components/Overlay.tsx
+++ b/src/components/Overlay.tsx
@@ -20,7 +20,7 @@ const OverlayBlock = styled.div<OverlayProps>`
   position: fixed;
   top: 0;
   left: 0;
-  z-index: 1;
+  z-index: 2;
 
   background: #000;
   opacity: ${ props => props.show ? '0.7' : '0' };


### PR DESCRIPTION
Fixed overlay shadow while opening the left menu.

before
![image](https://user-images.githubusercontent.com/43967788/114093475-d389cc00-98c3-11eb-8f3c-6f8b03752fb4.png)

after
![image](https://user-images.githubusercontent.com/43967788/114093504-dc7a9d80-98c3-11eb-9249-e9c3b925d32d.png)
