### PR TITLE
[Fix] Location instance block without id

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "st-retrospect-frontend",
-  "version": "1.1.1",
+  "version": "1.1.2",
   "private": false,
   "scripts": {
     "start": "react-scripts start",

--- a/src/components/RoutePassingRenderer.tsx
+++ b/src/components/RoutePassingRenderer.tsx
@@ -115,6 +115,16 @@ export default function RoutePassingRenderer(): ReactElement {
     let locationBlockWithTexts: QuestBlock[] = [];
 
     questDataBlocks.forEach(currentBlock => {
+      /**
+       * Skip location instance block without id
+       */
+      if (
+        currentBlock.type === 'locationInstance' &&
+        (!currentBlock.data.locationInstanceId || currentBlock.data.locationInstanceId === '')
+      ) {
+        return;
+      }
+
       if (
         (currentBlock.type === 'locationInstance' && locationBlockWithTexts.length === 0) ||
         currentBlock.type !== 'locationInstance'


### PR DESCRIPTION
Skip location instance without id in route passing.

Closes #141 